### PR TITLE
Update node-opencc@^2.0.0

### DIFF
--- a/lib/chinese-translator.coffee
+++ b/lib/chinese-translator.coffee
@@ -42,5 +42,5 @@ translate = (editor, translator) ->
   availableRanges = RangeFinder.rangesFor(editor)
   availableRanges.forEach (range) ->
     text = editor.getTextInBufferRange(range)
-    opencc[translator](text).then (result) ->
-      editor.setTextInBufferRange(range, result)
+    result = opencc[translator](text)
+    editor.setTextInBufferRange(range, result)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.4.0",
-    "node-opencc": "0.0.2"
+    "node-opencc": "^2.0.0"
   }
 }


### PR DESCRIPTION
`node-opencc` now uses synchronous API so `bluebird` is not required anymore.
